### PR TITLE
Fix create_plan initial_price check for EUR

### DIFF
--- a/paddle/_plans.py
+++ b/paddle/_plans.py
@@ -62,15 +62,15 @@ def create_plan(
     if main_currency_code == 'USD' and initial_price_usd is None:
         raise ValueError('main_currency_code is USD so initial_price_usd must be set')  # NOQA: E501
     if main_currency_code == 'GBP' and initial_price_gbp is None:
-        raise ValueError('main_currency_code is USD so initial_price_gbp must be set')  # NOQA: E501
-    if main_currency_code == 'USD' and initial_price_eur is None:
-        raise ValueError('main_currency_code is USD so initial_price_eur must be set')  # NOQA: E501
+        raise ValueError('main_currency_code is GBP so initial_price_gbp must be set')  # NOQA: E501
+    if main_currency_code == 'EUR' and initial_price_eur is None:
+        raise ValueError('main_currency_code is EUR so initial_price_eur must be set')  # NOQA: E501
     if main_currency_code == 'USD' and recurring_price_usd is None:
         raise ValueError('main_currency_code is USD so recurring_price_usd must be set')  # NOQA: E501
     if main_currency_code == 'GBP' and recurring_price_gbp is None:
-        raise ValueError('main_currency_code is USD so recurring_price_gbp must be set')  # NOQA: E501
-    if main_currency_code == 'USD' and recurring_price_eur is None:
-        raise ValueError('main_currency_code is USD so recurring_price_eur must be set')  # NOQA: E501
+        raise ValueError('main_currency_code is GBP so recurring_price_gbp must be set')  # NOQA: E501
+    if main_currency_code == 'EUR' and recurring_price_eur is None:
+        raise ValueError('main_currency_code is EUR so recurring_price_eur must be set')  # NOQA: E501
 
     json = {
         'plan_name': plan_name,

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -148,3 +148,36 @@ def test_create_plan_mock(mocker, paddle_client):  # NOQA: F811
         json=json,
         method=method,
     )
+
+
+@pytest.mark.parametrize(
+    'currency,missing_field',
+    [
+        ('USD', 'initial_price_usd'),
+        ('USD', 'recurring_price_usd'),
+        ('GBP', 'initial_price_gbp'),
+        ('GBP', 'recurring_price_gbp'),
+        ('EUR', 'initial_price_eur'),
+        ('EUR', 'recurring_price_eur'),
+    ]
+)
+def test_create_plan_missing_price(paddle_client, currency, missing_field):  # NOQA: F811, E501
+    plan = {
+        'plan_name': 'test_create_plan_mmissing_usd_initial',
+        'plan_trial_days': 999,
+        'plan_length': 999,
+        'plan_type': 'year',
+        'main_currency_code': currency,
+        'initial_price_usd': 0.0,
+        'initial_price_gbp': 0.0,
+        'initial_price_eur': 0.0,
+        'recurring_price_usd': 0.0,
+        'recurring_price_gbp': 0.0,
+        'recurring_price_eur': 0.0,
+    }
+    del plan[missing_field]
+    with pytest.raises(ValueError) as error:
+        paddle_client.create_plan(**plan)
+
+    message = r'main_currency_code is {0} so {1} must be set'
+    error.match(message.format(currency, missing_field))


### PR DESCRIPTION
Issue: https://github.com/paddle-python/paddle-client/issues/2

Bug fix and test to prove fix
Kept the ugly checks for now, it probably should be more DRY.
