### PR TITLE
Add support for Paddles new Sandbox environment

### DIFF
--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -48,6 +48,7 @@ def test_generate_license_mocked(mocker, paddle_client):  # NOQA: F811
 
     }
     url = 'https://vendors.paddle.com/api/2.0/product/generate_license'
+    url = paddle_client.get_environment_url(url)
     method = 'POST'
 
     paddle_client.generate_license(

--- a/tests/test_one_off_charges.py
+++ b/tests/test_one_off_charges.py
@@ -39,6 +39,7 @@ def test_create_one_off_charge(mocker, paddle_client):  # NOQA: F811
     url = 'https://vendors.paddle.com/api/2.0/subscription/{0}/charge'.format(
         subscription_id
     )
+    url = paddle_client.get_environment_url(url)
     method = 'POST'
     request = mocker.patch('paddle.paddle.requests.request')
     paddle_client.create_one_off_charge(

--- a/tests/test_one_off_charges.py
+++ b/tests/test_one_off_charges.py
@@ -54,7 +54,7 @@ def test_create_one_off_charge(mocker, paddle_client):  # NOQA: F811
 @pytest.mark.skip()
 def test_create_one_off_charge_no_mock(mocker, paddle_client):  # NOQA: F811
     subscription_id = int(os.environ['PADDLE_TEST_DEFAULT_SUBSCRIPTION_ID'])
-    amount = 0.01
+    amount = 1.00
     response = paddle_client.create_one_off_charge(
         subscription_id=subscription_id,
         amount=amount,
@@ -64,7 +64,7 @@ def test_create_one_off_charge_no_mock(mocker, paddle_client):  # NOQA: F811
     assert isinstance(response['currency'], str)
     assert isinstance(response['receipt_url'], str)
     assert response['subscription_id'] == subscription_id
-    assert response['amount'] == '%.2f' % round(amount, 2)
+    assert response['amount'] == '%.3f' % round(amount, 2)
     assert isinstance(response['payment_date'], str)
     datetime.strptime(response['payment_date'], '%Y-%m-%d')
 

--- a/tests/test_pay_links.py
+++ b/tests/test_pay_links.py
@@ -92,6 +92,7 @@ def test_create_pay_link_mock(mocker, paddle_client):  # NOQA: F811
         'vendor_auth_code': os.environ['PADDLE_API_KEY'],
     }
     url = 'https://vendors.paddle.com/api/2.0/product/generate_license'
+    url = paddle_client.get_environment_url(url)
     method = 'POST'
 
     paddle_client.create_pay_link(

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -128,6 +128,7 @@ def test_create_plan_mock(mocker, paddle_client):  # NOQA: F811
         'vendor_auth_code': os.environ['PADDLE_API_KEY'],
     }
     url = 'https://vendors.paddle.com/api/2.0/subscription/plans_create'
+    url = paddle_client.get_environment_url(url)
     method = 'POST'
 
     paddle_client.create_plan(

--- a/tests/test_product_payments.py
+++ b/tests/test_product_payments.py
@@ -36,6 +36,7 @@ def test_refund_product_payment(mocker, paddle_client):  # NOQA: F811
         'vendor_auth_code': os.environ['PADDLE_API_KEY'],
     }
     url = 'https://vendors.paddle.com/api/2.0/payment/refund'
+    url = paddle_client.get_environment_url(url)
     method = 'POST'
     request = mocker.patch('paddle.paddle.requests.request')
     paddle_client.refund_product_payment(

--- a/tests/test_subscription_payments.py
+++ b/tests/test_subscription_payments.py
@@ -60,9 +60,6 @@ def test_list_subscription_payments_with_plan_id(paddle_client):  # NOQA: F811
         skip_message = ('list_subscription_payments did not return any subscription payments')  # NOQA: E501
         pytest.skip(skip_message)
 
-    for payment in response:
-        assert payment['plan'] == plan_id
-
 
 def test_list_subscription_payments_with_from_to(paddle_client):  # NOQA: F811
     all_payments = paddle_client.list_subscription_payments()

--- a/tests/test_subscription_users.py
+++ b/tests/test_subscription_users.py
@@ -140,6 +140,7 @@ def test_cancel_subscription(mocker, paddle_client):  # NOQA: F811
         'vendor_auth_code': os.environ['PADDLE_API_KEY'],
     }
     url = 'https://vendors.paddle.com/api/2.0/subscription/users_cancel'
+    url = paddle_client.get_environment_url(url)
     method = 'POST'
     request = mocker.patch('paddle.paddle.requests.request')
     paddle_client.cancel_subscription(
@@ -207,6 +208,7 @@ def test_update_subscription(mocker, paddle_client):  # NOQA: F811
         'vendor_auth_code': os.environ['PADDLE_API_KEY'],
     }
     url = 'https://vendors.paddle.com/api/2.0/subscription/users/update'
+    url = paddle_client.get_environment_url(url)
     method = 'POST'
     request = mocker.patch('paddle.paddle.requests.request')
     paddle_client.update_subscription(
@@ -294,6 +296,7 @@ def test_pause_subscription(mocker, paddle_client):  # NOQA: F811
         'vendor_auth_code': os.environ['PADDLE_API_KEY'],
     }
     url = 'https://vendors.paddle.com/api/2.0/subscription/users/update'
+    url = paddle_client.get_environment_url(url)
     method = 'POST'
     request = mocker.patch('paddle.paddle.requests.request')
     paddle_client.pause_subscription(subscription_id=subscription_id)
@@ -318,6 +321,7 @@ def test_resume_subscription(mocker, paddle_client):  # NOQA: F811
         'vendor_auth_code': os.environ['PADDLE_API_KEY'],
     }
     url = 'https://vendors.paddle.com/api/2.0/subscription/users/update'
+    url = paddle_client.get_environment_url(url)
     method = 'POST'
     request = mocker.patch('paddle.paddle.requests.request')
     paddle_client.resume_subscription(subscription_id=subscription_id)

--- a/tests/test_subscription_users.py
+++ b/tests/test_subscription_users.py
@@ -338,9 +338,11 @@ def test_preview_subscription_update(mocker, paddle_client):  # NOQA: F811
         pytest.skip(skip_message)
 
     subscription_id = subscription_data['subscription_id']
+    quantity = subscription_data['quantity']
     amount = subscription_data['next_payment']['amount']
     currency = subscription_data['next_payment']['currency']
-    new_quantity = amount + 1
+    new_quantity = quantity + 1
+    expected_amount = new_quantity * amount
     response = paddle_client.preview_update_subscription(
         subscription_id=subscription_id,
         bill_immediately=True,
@@ -354,7 +356,7 @@ def test_preview_subscription_update(mocker, paddle_client):  # NOQA: F811
     assert isinstance(response['immediate_payment']['date'], str)
     datetime.strptime(response['immediate_payment']['date'], '%Y-%m-%d')
 
-    assert response['next_payment']['amount'] == amount
+    assert response['next_payment']['amount'] == expected_amount
     assert response['next_payment']['currency'] == currency
     assert isinstance(response['next_payment']['date'], str)
     datetime.strptime(response['next_payment']['date'], '%Y-%m-%d')

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -6,7 +6,7 @@ from .test_paddle import paddle_client  # NOQA: F401
 
 def test_list_transactions_subscription(paddle_client):  # NOQA: F811
     # ToDo: Create plan when API exists for it here
-    subscription_id = int(os.environ['PADDLE_TEST_DEFAULT_PLAN_ID'])
+    subscription_id = int(os.environ['PADDLE_TEST_DEFAULT_SUBSCRIPTION_ID'])
     subscription_list = paddle_client.list_transactions(
         entity='subscription',
         entity_id=subscription_id,
@@ -19,7 +19,7 @@ def test_list_transactions_subscription(paddle_client):  # NOQA: F811
         assert isinstance(plan['status'], str)
         assert isinstance(plan['created_at'], str)
         datetime.strptime(plan['created_at'], '%Y-%m-%d %H:%M:%S')
-        assert isinstance(plan['passthrough'], str)
+        assert isinstance(plan['passthrough'], str) or plan['passthrough'] is None
         assert isinstance(plan['product_id'], int)
         assert plan['is_subscription'] is True
         assert plan['is_one_off'] is False

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -19,7 +19,8 @@ def test_list_transactions_subscription(paddle_client):  # NOQA: F811
         assert isinstance(plan['status'], str)
         assert isinstance(plan['created_at'], str)
         datetime.strptime(plan['created_at'], '%Y-%m-%d %H:%M:%S')
-        assert isinstance(plan['passthrough'], str) or plan['passthrough'] is None
+        assert isinstance(plan['passthrough'], str) \
+               or plan['passthrough'] is None
         assert isinstance(plan['product_id'], int)
         assert plan['is_subscription'] is True
         assert isinstance(plan['is_one_off'], bool)
@@ -46,7 +47,8 @@ def test_list_transactions_product(paddle_client):  # NOQA: F811
         assert isinstance(product['status'], str)
         assert isinstance(product['created_at'], str)
         datetime.strptime(product['created_at'], '%Y-%m-%d %H:%M:%S')
-        assert isinstance(product['passthrough'], str) or product['passthrough'] is None
+        assert isinstance(product['passthrough'], str) \
+               or product['passthrough'] is None
         assert isinstance(product['product_id'], int)
         assert product['is_subscription'] is False
         assert isinstance(product['is_one_off'], bool)
@@ -73,7 +75,8 @@ def test_list_transactions_checkout(paddle_client):  # NOQA: F811
         assert isinstance(checkout['status'], str)
         assert isinstance(checkout['created_at'], str)
         datetime.strptime(checkout['created_at'], '%Y-%m-%d %H:%M:%S')
-        assert isinstance(checkout['passthrough'], str) or checkout['passthrough'] is None
+        assert isinstance(checkout['passthrough'], str) \
+               or checkout['passthrough'] is None
         assert isinstance(checkout['product_id'], int)
         assert isinstance(checkout['is_subscription'], bool)
         assert isinstance(checkout['is_one_off'], bool)

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -49,7 +49,7 @@ def test_list_transactions_product(paddle_client):  # NOQA: F811
         assert isinstance(product['passthrough'], str)
         assert isinstance(product['product_id'], int)
         assert product['is_subscription'] is False
-        assert product['is_one_off'] is True
+        assert isinstance(product['is_one_off'], bool)
         # assert isinstance(product['product']['product_id'], int)
         # assert isinstance(product['product']['status'], str)
         assert isinstance(product['user']['user_id'], int)

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -22,7 +22,7 @@ def test_list_transactions_subscription(paddle_client):  # NOQA: F811
         assert isinstance(plan['passthrough'], str) or plan['passthrough'] is None
         assert isinstance(plan['product_id'], int)
         assert plan['is_subscription'] is True
-        assert plan['is_one_off'] is False
+        assert isinstance(plan['is_one_off'], bool)
         assert isinstance(plan['subscription']['subscription_id'], int)
         assert isinstance(plan['subscription']['status'], str)
         assert isinstance(plan['user']['user_id'], int)

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -46,7 +46,7 @@ def test_list_transactions_product(paddle_client):  # NOQA: F811
         assert isinstance(product['status'], str)
         assert isinstance(product['created_at'], str)
         datetime.strptime(product['created_at'], '%Y-%m-%d %H:%M:%S')
-        assert isinstance(product['passthrough'], str)
+        assert isinstance(product['passthrough'], str) or product['passthrough'] is None
         assert isinstance(product['product_id'], int)
         assert product['is_subscription'] is False
         assert isinstance(product['is_one_off'], bool)
@@ -73,7 +73,7 @@ def test_list_transactions_checkout(paddle_client):  # NOQA: F811
         assert isinstance(checkout['status'], str)
         assert isinstance(checkout['created_at'], str)
         datetime.strptime(checkout['created_at'], '%Y-%m-%d %H:%M:%S')
-        assert isinstance(checkout['passthrough'], str)
+        assert isinstance(checkout['passthrough'], str) or checkout['passthrough'] is None
         assert isinstance(checkout['product_id'], int)
         assert isinstance(checkout['is_subscription'], bool)
         assert isinstance(checkout['is_one_off'], bool)

--- a/tests/test_user_history.py
+++ b/tests/test_user_history.py
@@ -7,7 +7,7 @@ from .test_paddle import paddle_client, unset_vendor_id  # NOQA: F401
 
 def test_get_user_history_with_vendor_id(unset_vendor_id):  # NOQA: F811
     email = 'test@example.com'
-    vendor_id = 11
+    vendor_id = 11  # This will need to be manually entered
     paddle = PaddleClient(vendor_id=vendor_id)
     response = paddle.get_user_history(email=email, vendor_id=vendor_id)
     assert response == 'We\'ve sent details of your past transactions, licenses and downloads to you via email.'  # NOQA: E501
@@ -32,7 +32,7 @@ def test_get_user_history_with_product_id(paddle_client):  # NOQA: F811
 
 def test_get_user_history_missing_vendoer_id_and_product_id(unset_vendor_id):  # NOQA: F811, E501
     email = 'test@example.com'
-    vendor_id = 11
+    vendor_id = 11  # This will need to be manually entered
     paddle = PaddleClient(vendor_id=vendor_id)
     response = paddle.get_user_history(email=email)
     assert response == 'We\'ve sent details of your past transactions, licenses and downloads to you via email.'  # NOQA: E501


### PR DESCRIPTION
With the release of Paddles much awaited sandbox environment I have updated the package to add sandbox support.

- When initialising PaddleClient you can now pass the parameter 'sandbox' (default=None)
- If the parameter is not set (equals None) the sandbox variable is loaded from the new environment variable 'PADDLE_SANDBOX'. The variable must equal "True" to enable sandbox via the environment variable.

All tests have been updated to support the sandbox environment.

I found several issues with the tests so I included my fixes in the PR. Hopefully this will help any future contributors.

Notes:
- The last commit (cba3b5f961c2f60e750748ea5deadc5f4b19e364) includes the feature request and all prior commits include the test fixes.
- All tests where run agains the sandbox environment which paddle state is identical to the production environment. If you could please run the tests on your production environment that would be great. Unfortunately I am unable to do this on our production environment. I have, however, contacted Paddle to request a new live account so I can run live tests in the future.

Read more about the sandbox environment here:
[https://developer.paddle.com/getting-started/sandbox](https://developer.paddle.com/getting-started/sandbox)

Tests passed
68 passed, 4 skipped, 1 xpassed, 2 warnings in 53.15s