### PR TITLE
Pay link state - vat_state not required

### DIFF
--- a/paddle/_pay_links.py
+++ b/paddle/_pay_links.py
@@ -83,8 +83,6 @@ def create_pay_link(
             raise ValueError('vat_street must be set if vat_number is set')
         if not vat_city:
             raise ValueError('vat_city must be set if vat_number is set')
-        if not vat_state:
-            raise ValueError('vat_state must be set if vat_number is set')
         if not vat_country:
             raise ValueError('vat_country must be set if vat_number is set')
         if vat_country in countries_requiring_postcode and not vat_postcode:  # NOQA: E501

--- a/tests/test_pay_links.py
+++ b/tests/test_pay_links.py
@@ -126,14 +126,6 @@ def test_create_pay_link_vat_number(paddle_client):  # NOQA: F811
         paddle_client.create_pay_link(
             title='test', webhook_url='fake', vat_number='1234',
             vat_company_name='name', vat_street='street',
-            vat_city='city',
-        )
-    error.match('vat_state must be set if vat_number is set')
-
-    with pytest.raises(ValueError) as error:
-        paddle_client.create_pay_link(
-            title='test', webhook_url='fake', vat_number='1234',
-            vat_company_name='name', vat_street='street',
             vat_city='city', vat_state='state',
         )
     error.match('vat_country must be set if vat_number is set')


### PR DESCRIPTION
According to Paddle doc: https://developer.paddle.com/api-reference/3f031a63f6bae-generate-pay-link
vat_state is NOT required

fixes #11 